### PR TITLE
Update permission_policy.dart

### DIFF
--- a/lib/permission_policy.dart
+++ b/lib/permission_policy.dart
@@ -80,7 +80,7 @@ class PermissionPolicy {
       List<String> permissions =
           PermissionPolicy.instance.findPermissionsForRole(role);
 
-      if (permissions.contains(role)) {
+      if (permissions.contains(permission)) {
         return true;
       }
     }


### PR DESCRIPTION
Fixed `hasPermission()` always returning false bug, in `hasPermission()` function, I am now checking permission inside permissions list instead of role.